### PR TITLE
Disable nagle on whois sockets

### DIFF
--- a/irrd/server/whois/protocol.py
+++ b/irrd/server/whois/protocol.py
@@ -35,6 +35,9 @@ class WhoisQueryReceiver(TimeoutMixin, LineOnlyReceiver):
             self.transport.loseConnection()
             return
 
+        # disable nagle
+        self.transport.setTcpNoDelay(True)
+
         self.peer_str = f'[{peer.host}]:{peer.port}'
 
         self.query_parser = WhoisQueryParser(peer, self.peer_str)

--- a/irrd/server/whois/tests/test_protocol.py
+++ b/irrd/server/whois/tests/test_protocol.py
@@ -128,7 +128,8 @@ class TestWhoisProtocol:
         receiver.factory = mock_factory
 
         receiver.connectionMade()
-        assert len(mock_transport.mock_calls) == 0
+        # with setTcpNoDelay(True) this should be 1
+        assert len(mock_transport.mock_calls) == 1
 
     def test_whois_protocol_access_list_denied(self, config_override):
         config_override({


### PR DESCRIPTION
This incorporates https://github.com/haussli/irrd4 with a fixed
junit test.