### PR TITLE
Add documentation URL to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,9 @@ older versions lead to the IRRd v4 project.
 This project was commissioned by NTT_ and designed and developed by
 DashCare_.
 
+Please see the documentation_ for more.
+
 .. _NTT: https://us.ntt.net
 .. _DashCare: https://www.dashcare.nl
 .. _Older versions: https://github.com/irrdnet/irrd
+.. _documentation: http://irrd4.readthedocs.io/en/latest/


### PR DESCRIPTION
This PR adds a link to the documentation site in README.

The documentation URL is in the project description on Github, but once you clone the project, it is not mentioned in the README file. Also, many people barely glance at the description and skip straight to README contents.