### PR TITLE
Fix #228 - Fix incorrect reference error when deleting objects with no inbound refs

### DIFF
--- a/irrd/updates/validators.py
+++ b/irrd/updates/validators.py
@@ -113,6 +113,8 @@ class ReferenceValidator:
         that is also about to be deleted, is acceptable.
         """
         result = ValidatorResult()
+        if not rpsl_obj.references_inbound():
+            return result
 
         query = RPSLDatabaseQuery().sources([rpsl_obj.source()])
         query = query.lookup_attrs_in(rpsl_obj.references_inbound(), [rpsl_obj.pk()])


### PR DESCRIPTION
Deleting an object without inbound refs would fail, as the reference
check query would be too wide and therefore detect false inbound
references. This affected route objects and possibly others, where
admin-c/tech-c are optional.