### PR TITLE
Update pytest to 5.1.2 and fix failing unit tests

### DIFF
--- a/irrd/conf/test_conf.py
+++ b/irrd/conf/test_conf.py
@@ -23,7 +23,7 @@ class TestConfiguration:
     def test_file_not_existing(self, monkeypatch, tmpdir):
         with pytest.raises(ConfigurationError) as ce:
             config_init(str(tmpdir + '/doesnotexist.yaml'))
-        assert 'Error opening config file' in str(ce)
+        assert 'Error opening config file' in str(ce.value)
 
     def test_load_invalid_yaml(self, monkeypatch, tmpdir):
         tmp_file = tmpdir + '/config.yaml'
@@ -33,17 +33,17 @@ class TestConfiguration:
 
         with pytest.raises(ConfigurationError) as ce:
             config_init(str(tmp_file))
-        assert 'Error parsing YAML file' in str(ce)
+        assert 'Error parsing YAML file' in str(ce.value)
 
     def test_load_string_file(self, save_yaml_config):
         with pytest.raises(ConfigurationError) as ce:
             save_yaml_config('foo')
-        assert 'Could not find root item "irrd" in config file' in str(ce)
+        assert 'Could not find root item "irrd" in config file' in str(ce.value)
 
     def test_load_empty_config(self, save_yaml_config):
         with pytest.raises(ConfigurationError) as ce:
             save_yaml_config({})
-        assert 'Could not find root item "irrd" in config file' in str(ce)
+        assert 'Could not find root item "irrd" in config file' in str(ce.value)
 
     def test_load_valid_reload_valid_config(self, monkeypatch, save_yaml_config, tmpdir, caplog):
         logfile = str(tmpdir + '/logfile.txt')
@@ -192,25 +192,25 @@ class TestConfiguration:
         with pytest.raises(ConfigurationError) as ce:
             save_yaml_config(config)
 
-        assert 'Setting database_url is required.' in str(ce)
-        assert 'Setting email.from is required and must be an email address.' in str(ce)
-        assert 'Setting email.smtp is required.' in str(ce)
-        assert 'Setting email.footer must be a string, if defined.' in str(ce)
-        assert 'Setting auth.gnupg_keyring is required.' in str(ce)
-        assert 'Access lists doesnotexist referenced in settings, but not defined.' in str(ce)
-        assert 'Setting server.http.access_list must be a string, if defined.' in str(ce)
-        assert 'Invalid item in access list bad-list: IPv4 Address with more than 4 bytes.' in str(ce)
-        assert 'Setting sources_default contains unknown sources: DOESNOTEXIST-DB' in str(ce)
-        assert 'Setting keep_journal for source TESTDB can not be enabled unless either ' in str(ce)
-        assert 'Setting nrtm_host for source TESTDB can not be enabled without setting import_serial_source.' in str(ce)
-        assert 'Setting authoritative for source TESTDB2 can not be enabled when either nrtm_host or import_source are set.' in str(ce)
-        assert 'Setting authoritative for source TESTDB3 can not be enabled when either nrtm_host or import_source are set.' in str(ce)
-        assert 'Setting nrtm_port for source TESTDB2 must be a number.' in str(ce)
-        assert 'Setting import_timer for source TESTDB must be a number.' in str(ce)
-        assert 'Setting export_timer for source TESTDB must be a number.' in str(ce)
-        assert 'Invalid source name: lowercase' in str(ce)
-        assert 'Invalid source name: invalid char' in str(ce)
-        assert 'Invalid log.level: INVALID' in str(ce)
+        assert 'Setting database_url is required.' in str(ce.value)
+        assert 'Setting email.from is required and must be an email address.' in str(ce.value)
+        assert 'Setting email.smtp is required.' in str(ce.value)
+        assert 'Setting email.footer must be a string, if defined.' in str(ce.value)
+        assert 'Setting auth.gnupg_keyring is required.' in str(ce.value)
+        assert 'Access lists doesnotexist referenced in settings, but not defined.' in str(ce.value)
+        assert 'Setting server.http.access_list must be a string, if defined.' in str(ce.value)
+        assert 'Invalid item in access list bad-list: IPv4 Address with more than 4 bytes.' in str(ce.value)
+        assert 'Setting sources_default contains unknown sources: DOESNOTEXIST-DB' in str(ce.value)
+        assert 'Setting keep_journal for source TESTDB can not be enabled unless either ' in str(ce.value)
+        assert 'Setting nrtm_host for source TESTDB can not be enabled without setting import_serial_source.' in str(ce.value)
+        assert 'Setting authoritative for source TESTDB2 can not be enabled when either nrtm_host or import_source are set.' in str(ce.value)
+        assert 'Setting authoritative for source TESTDB3 can not be enabled when either nrtm_host or import_source are set.' in str(ce.value)
+        assert 'Setting nrtm_port for source TESTDB2 must be a number.' in str(ce.value)
+        assert 'Setting import_timer for source TESTDB must be a number.' in str(ce.value)
+        assert 'Setting export_timer for source TESTDB must be a number.' in str(ce.value)
+        assert 'Invalid source name: lowercase' in str(ce.value)
+        assert 'Invalid source name: invalid char' in str(ce.value)
+        assert 'Invalid log.level: INVALID' in str(ce.value)
 
 
 class TestGetSetting:

--- a/irrd/mirroring/tests/test_mirror_runners_import.py
+++ b/irrd/mirroring/tests/test_mirror_runners_import.py
@@ -305,7 +305,7 @@ class TestMirrorFullImportRunner:
         mock_dh = Mock()
         with pytest.raises(ValueError) as ve:
             MirrorFullImportRunner('TEST').run(mock_dh)
-        assert 'scheme gopher is not supported' in str(ve)
+        assert 'scheme gopher is not supported' in str(ve.value)
 
 
 class MockMirrorFileImportParser:

--- a/irrd/mirroring/tests/test_nrtm_generator.py
+++ b/irrd/mirroring/tests/test_nrtm_generator.py
@@ -107,28 +107,28 @@ class TestNRTMGenerator:
 
         with pytest.raises(NRTMGeneratorException) as nge:
             generator.generate('TEST', '3', 200, 190, mock_dh)
-        assert 'Start of the serial range (200) must be lower or equal to end of the serial range (190)' in str(nge)
+        assert 'Start of the serial range (200) must be lower or equal to end of the serial range (190)' in str(nge.value)
 
     def test_serial_start_too_low(self, prepare_generator):
         generator, mock_dh = prepare_generator
 
         with pytest.raises(NRTMGeneratorException) as nge:
             generator.generate('TEST', '3', 10, 190, mock_dh)
-        assert 'Serials 10 - 100 do not exist' in str(nge)
+        assert 'Serials 10 - 100 do not exist' in str(nge.value)
 
     def test_serial_start_too_high(self, prepare_generator):
         generator, mock_dh = prepare_generator
 
         with pytest.raises(NRTMGeneratorException) as nge:
             generator.generate('TEST', '3', 202, None, mock_dh)
-        assert 'Serials 200 - 202 do not exist' in str(nge)
+        assert 'Serials 200 - 202 do not exist' in str(nge.value)
 
     def test_serial_end_too_high(self, prepare_generator):
         generator, mock_dh = prepare_generator
 
         with pytest.raises(NRTMGeneratorException) as nge:
             generator.generate('TEST', '3', 110, 300, mock_dh)
-        assert 'Serials 200 - 300 do not exist' in str(nge)
+        assert 'Serials 200 - 300 do not exist' in str(nge.value)
 
     def test_no_new_updates(self, prepare_generator):
         # This message is only triggered when starting from a serial
@@ -159,7 +159,7 @@ class TestNRTMGenerator:
 
         with pytest.raises(NRTMGeneratorException) as nge:
             generator.generate('TEST', '3', 110, 300, mock_dh)
-        assert 'No journal kept for this source, unable to serve NRTM queries' in str(nge)
+        assert 'No journal kept for this source, unable to serve NRTM queries' in str(nge.value)
 
     def test_no_source_status_entry(self, prepare_generator, config_override):
         generator, mock_dh = prepare_generator
@@ -167,4 +167,4 @@ class TestNRTMGenerator:
 
         with pytest.raises(NRTMGeneratorException) as nge:
             generator.generate('TEST', '3', 110, 300, mock_dh)
-        assert 'There are no journal entries for this source.' in str(nge)
+        assert 'There are no journal entries for this source.' in str(nge.value)

--- a/irrd/mirroring/tests/test_parsers.py
+++ b/irrd/mirroring/tests/test_parsers.py
@@ -181,7 +181,7 @@ class TestNRTMStreamParser:
             NRTMStreamParser('TEST', SAMPLE_NRTM_V3_SERIAL_OUT_OF_ORDER, mock_dh)
 
         error_msg = 'expected at least'
-        assert error_msg in str(ve)
+        assert error_msg in str(ve.value)
         assert len(mock_dh.mock_calls) == 1
         assert mock_dh.mock_calls[0][0] == 'record_mirror_error'
         assert mock_dh.mock_calls[0][1][0] == 'TEST'
@@ -193,7 +193,7 @@ class TestNRTMStreamParser:
             NRTMStreamParser('BADSOURCE', SAMPLE_NRTM_V3, mock_dh)
 
         error_msg = 'Invalid NRTM source in START line: expected BADSOURCE but found TEST '
-        assert error_msg in str(ve)
+        assert error_msg in str(ve.value)
         assert len(mock_dh.mock_calls) == 1
         assert mock_dh.mock_calls[0][0] == 'record_mirror_error'
         assert mock_dh.mock_calls[0][1][0] == 'BADSOURCE'
@@ -204,7 +204,7 @@ class TestNRTMStreamParser:
         with pytest.raises(ValueError) as ve:
             NRTMStreamParser('TEST', SAMPLE_NRTM_V1_TOO_MANY_ITEMS, mock_dh)
         error_msg = 'expected operations up to and including'
-        assert error_msg in str(ve)
+        assert error_msg in str(ve.value)
 
         assert len(mock_dh.mock_calls) == 1
         assert mock_dh.mock_calls[0][0] == 'record_mirror_error'
@@ -217,7 +217,7 @@ class TestNRTMStreamParser:
             NRTMStreamParser('TEST', SAMPLE_NRTM_INVALID_VERSION, mock_dh)
 
         error_msg = 'Invalid NRTM version 99 in START line'
-        assert error_msg in str(ve)
+        assert error_msg in str(ve.value)
         assert len(mock_dh.mock_calls) == 1
         assert mock_dh.mock_calls[0][0] == 'record_mirror_error'
         assert mock_dh.mock_calls[0][1][0] == 'TEST'
@@ -229,7 +229,7 @@ class TestNRTMStreamParser:
             NRTMStreamParser('TEST', SAMPLE_NRTM_V3_INVALID_MULTIPLE_START_LINES, mock_dh)
 
         error_msg = 'Encountered second START line'
-        assert error_msg in str(ve)
+        assert error_msg in str(ve.value)
 
         assert len(mock_dh.mock_calls) == 1
         assert mock_dh.mock_calls[0][0] == 'record_mirror_error'
@@ -242,7 +242,7 @@ class TestNRTMStreamParser:
             NRTMStreamParser('TEST', SAMPLE_NRTM_INVALID_NO_START_LINE, mock_dh)
 
         error_msg = 'Encountered operation before valid NRTM START line'
-        assert error_msg in str(ve)
+        assert error_msg in str(ve.value)
         assert len(mock_dh.mock_calls) == 1
         assert mock_dh.mock_calls[0][0] == 'record_mirror_error'
         assert mock_dh.mock_calls[0][1][0] == 'TEST'

--- a/irrd/rpsl/tests/test_rpsl_objects.py
+++ b/irrd/rpsl/tests/test_rpsl_objects.py
@@ -27,7 +27,7 @@ class TestRPSLParsingGeneric:
     def test_unknown_class(self):
         with raises(UnknownRPSLObjectClassException) as ve:
             rpsl_object_from_text(SAMPLE_UNKNOWN_CLASS)
-        assert 'unknown object class' in str(ve)
+        assert 'unknown object class' in str(ve.value)
 
     def test_malformed_empty_line(self):
         obj = rpsl_object_from_text(SAMPLE_MALFORMED_EMPTY_LINE, strict_validation=False)

--- a/irrd/server/whois/tests/test_query_response.py
+++ b/irrd/server/whois/tests/test_query_response.py
@@ -48,19 +48,19 @@ class TestWhoisQueryResponse:
             # noinspection PyTypeChecker
             WhoisQueryResponse(mode='bar', response_type=WhoisQueryResponseType.ERROR,
                                result='foo').generate_response()  # type:ignore
-        assert 'foo' in str(ve)
+        assert 'foo' in str(ve.value)
 
         with raises(RuntimeError) as ve:
             # noinspection PyTypeChecker
             WhoisQueryResponse(mode=WhoisQueryResponseMode.IRRD,
                                response_type='foo', result='foo').generate_response()  # type:ignore
-        assert 'foo' in str(ve)
+        assert 'foo' in str(ve.value)
 
         with raises(RuntimeError) as ve:
             # noinspection PyTypeChecker
             WhoisQueryResponse(mode=WhoisQueryResponseMode.RIPE,
                                response_type='foo', result='foo').generate_response()  # type:ignore
-        assert 'foo' in str(ve)
+        assert 'foo' in str(ve.value)
 
     def test_auth_hash_removal(self):
         response = WhoisQueryResponse(mode=WhoisQueryResponseMode.RIPE,

--- a/irrd/storage/tests/test_database.py
+++ b/irrd/storage/tests/test_database.py
@@ -557,12 +557,12 @@ class TestRPSLDatabaseQueryLive:
     def test_modify_frozen_filter(self):
         with raises(ValueError) as ve:
             RPSLDatabaseQuery().ip_less_specific_one_level(IP('192.0.2.0/27')).sources(['TEST'])
-        assert 'frozen' in str(ve)
+        assert 'frozen' in str(ve.value)
 
     def test_invalid_lookup_attribute(self):
         with raises(ValueError) as ve:
             RPSLDatabaseQuery().lookup_attr('not-a-lookup-attr', 'value')
-        assert 'Invalid lookup attribute' in str(ve)
+        assert 'Invalid lookup attribute' in str(ve.value)
 
     def _assert_match(self, query):
         __tracebackhide__ = True

--- a/irrd/storage/tests/test_preload.py
+++ b/irrd/storage/tests/test_preload.py
@@ -114,7 +114,7 @@ class TestPreloader:
 
         with pytest.raises(ValueError) as ve:
             preloader.routes_for_origins(['AS65547'], sources, 2)
-        assert 'Invalid IP version: 2' in str(ve)
+        assert 'Invalid IP version: 2' in str(ve.value)
 
 
 class TestPreloadUpdater:

--- a/irrd/updates/tests/test_parser.py
+++ b/irrd/updates/tests/test_parser.py
@@ -803,7 +803,7 @@ class TestSingleChangeRequestHandling:
 
         with pytest.raises(ValueError) as ve:
             result_unknown.notification_target_report()
-        assert 'changes that are valid or have failed authorisation' in str(ve)
+        assert 'changes that are valid or have failed authorisation' in str(ve.value)
 
     def _request_text(self):
         unknown_class = 'unknown-object: foo\n'

--- a/irrd/utils/tests/test_validators.py
+++ b/irrd/utils/tests/test_validators.py
@@ -9,12 +9,12 @@ def test_validate_as_number():
 
     with raises(ValidationError) as ve:
         parse_as_number('12345')
-    assert 'must start with' in str(ve)
+    assert 'must start with' in str(ve.value)
 
     with raises(ValidationError) as ve:
         parse_as_number('ASFOO')
-    assert 'number part is not numeric' in str(ve)
+    assert 'number part is not numeric' in str(ve.value)
 
     with raises(ValidationError) as ve:
         parse_as_number('AS429496729999')
-    assert 'maximum value is' in str(ve)
+    assert 'maximum value is' in str(ve.value)

--- a/irrd/utils/tests/test_whois_client.py
+++ b/irrd/utils/tests/test_whois_client.py
@@ -163,7 +163,7 @@ class TestWhoisQueryIRRD:
         mock_socket.recv = mock_socket_recv
         with pytest.raises(WhoisQueryError) as wqe:
             whois_query_irrd('192.0.2.1', 43, 'query')
-        assert 'unrecognized command' in str(wqe)
+        assert 'unrecognized command' in str(wqe.value)
 
         assert flatten_mock_calls(mock_socket) == [
             ['settimeout', (5,), {}],
@@ -187,7 +187,7 @@ class TestWhoisQueryIRRD:
         mock_socket.recv = mock_socket_recv
         with pytest.raises(ValueError) as ve:
             whois_query_irrd('192.0.2.1', 43, 'query')
-        assert 'without a valid IRRD-format response' in str(ve)
+        assert 'without a valid IRRD-format response' in str(ve.value)
 
         assert flatten_mock_calls(mock_socket) == [
             ['settimeout', (5,), {}],
@@ -213,7 +213,7 @@ class TestWhoisQueryIRRD:
         mock_socket.recv = mock_socket_recv
         with pytest.raises(ValueError) as ve:
             whois_query_irrd('192.0.2.1', 43, 'query')
-        assert 'Unable to receive ' in str(ve)
+        assert 'Unable to receive ' in str(ve.value)
 
         assert flatten_mock_calls(mock_socket) == [
             ['settimeout', (5,), {}],
@@ -239,7 +239,7 @@ class TestWhoisQueryIRRD:
         mock_socket.recv = mock_socket_recv
         with pytest.raises(ValueError) as ve:
             whois_query_irrd('192.0.2.1', 43, 'query')
-        assert 'Unable to receive ' in str(ve)
+        assert 'Unable to receive ' in str(ve.value)
 
         assert flatten_mock_calls(mock_socket) == [
             ['settimeout', (5,), {}],
@@ -293,7 +293,7 @@ class TestQuerySourceStatus:
 
         with pytest.raises(ValueError) as ve:
             whois_query_source_status('host', 43, 'TEST')
-        assert 'Received invalid source NOT-TEST' in str(ve)
+        assert 'Received invalid source NOT-TEST' in str(ve.value)
 
     def test_query_empty_response(self, monkeypatch):
         def mock_whois_query_irrd(host: str, port: int, query: str) -> Optional[str]:
@@ -306,4 +306,4 @@ class TestQuerySourceStatus:
 
         with pytest.raises(ValueError) as ve:
             whois_query_source_status('host', 43, 'TEST')
-        assert 'empty response' in str(ve)
+        assert 'empty response' in str(ve.value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ ujson==1.35
 twisted==19.7.0
 
 # Testing and related packages
-pytest==4.6.3  # pyup: <5
+pytest==5.1.2
 pytest-cov==2.7.1
 coverage==4.5.4
 coveralls==1.8.2


### PR DESCRIPTION
Fix #249 

This updates the requirements.txt file to leverage pytest 5.1.2 and leverages the updated exception syntax in the failing unit tests per the following links to resolve the failures:

https://docs.pytest.org/en/latest/assert.html#assertions-about-expected-exceptions
https://docs.pytest.org/en/latest/reference.html#pytest-raises

Please let me know if there are any questions